### PR TITLE
Add wrappers for 2022.08-1 toolchain

### DIFF
--- a/test_build_all.sh
+++ b/test_build_all.sh
@@ -4,6 +4,8 @@ set -o xtrace
 
 bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:x86-64-linux-gnu-2021.11-5 //test:test_cpp
 bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:x86-64-linux-gnu-2021.11-5 //test:test_c
+bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:x86-64-linux-gnu-2022.08-1 //test:test_cpp
+bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:x86-64-linux-gnu-2022.08-1 //test:test_c
 bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:x86-64-core-i7-linux-gnu-2020.08-1 //test:test_cpp
 bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:x86-64-core-i7-linux-gnu-2020.08-1 //test:test_c
 bazel build --verbose_failures --platforms=@bazel_bootlin//platforms:aarch64-linux-gnu-2021.11-1 //test:test_cpp

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-ar
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-ar
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-ar $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-cpp
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-cpp
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-cpp.br_real $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-gcc
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-gcc
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-gcc.br_real $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-gcov
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-gcov
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-gcov $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-ld
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-ld
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-ld $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-nm
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-nm
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-nm $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-objdump
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-objdump
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-objdump $@

--- a/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-strip
+++ b/toolchains/tool_wrappers/x86-64/2022.08-1/x86-64-linux-gnu-2022.08-1-strip
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec external/x86-64-linux-gnu-2022.08-1/bin/x86_64-buildroot-linux-gnu-strip $@


### PR DESCRIPTION
Missing wrappers for the gcc-x86-64-2022.08-1 toolchain.